### PR TITLE
Upgrade to DuckDb.Net 1.5.0, corresponding to DuckDb 1.5.0

### DIFF
--- a/UnitTests/UnitTestDuckDbQueries.cs
+++ b/UnitTests/UnitTestDuckDbQueries.cs
@@ -192,6 +192,16 @@ public class UnitTestDuckDbQueries
         Assert.IsInstanceOfType(data[1, 0], typeof(string));
         Assert.AreEqual("{\"duck\": 42}", data[1, 0]);
     }
+        
+    [TestMethod]
+    [Ignore("DuckDb.Net does not support variants yet")]
+    public void TestVariant()
+    {
+        var data = DuckDbHelper.ExecuteQuery("SELECT 42::VARIANT");
+        Assert.IsNotNull(data);
+        Assert.IsInstanceOfType(data[1, 0], typeof(int));
+        Assert.AreEqual(42, data[1, 0]);
+    }
 
     [TestMethod]
     public void TestSmallInteger()
@@ -297,7 +307,7 @@ public class UnitTestDuckDbQueries
     [TestMethod]
     public void TestCommunityExtension()
     {
-        var data = DuckDbHelper.ExecuteQuery("INSTALL ofquack FROM community;LOAD ofquack;SELECT 'Success'");
+        var data = DuckDbHelper.ExecuteQuery("INSTALL quack FROM community;LOAD quack;SELECT 'Success'");
         Assert.IsNotNull(data);
         Assert.AreEqual("Success", data[1, 0]);
     }

--- a/xlDuckDb/xlDuckDb.csproj
+++ b/xlDuckDb/xlDuckDb.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.3.2" />
-    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.3.2" />
+    <PackageReference Include="DuckDB.NET.Bindings.Full" Version="1.5.0" />
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.0" />
     <PackageReference Include="ExcelDna.AddIn" Version="1.9.0" />
     <PackageReference Include="ExcelDna.Interop" Version="15.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Note that VARIANTs are not yet supported in DuckDb.Net