### PR TITLE
Render LIST, ARRAY, STRUCT, and MAP columns as JSON strings instead of #VALUE!

### DIFF
--- a/UnitTests/UnitTestDuckDbQueries.cs
+++ b/UnitTests/UnitTestDuckDbQueries.cs
@@ -1,5 +1,6 @@
 ﻿using ExcelDna.Integration;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using xlDuckDb;
 using Xunit;
 
@@ -254,5 +255,52 @@ public class UnitTestDuckDbQueries
         Assert.NotNull(data);
         Assert.IsType<DateTime>(data[1, 0]);
         Assert.Equal(new DateTime(1992, 9, 20, 10, 30, 0), data[1, 0]);
+    }
+
+    [Fact]
+    public void TestList()
+    {
+        var data = DuckDbHelper.ExecuteQuery("SELECT ['apple', 'banana', 'cherry']");
+        Assert.NotNull(data);
+        var json = Assert.IsType<string>(data[1, 0]);
+        var list = JsonSerializer.Deserialize<List<string>>(json);
+        Assert.NotNull(list);
+        Assert.Equal(3, list.Count);
+        Assert.Equal("apple", list[0]);
+        Assert.Equal("banana", list[1]);
+        Assert.Equal("cherry", list[2]);
+    }
+
+    [Fact]
+    public void TestNullList()
+    {
+        var data = DuckDbHelper.ExecuteQuery("SELECT NULL::INTEGER[]");
+        Assert.NotNull(data);
+        Assert.IsType<ExcelError>(data[1, 0]);
+        Assert.Equal(ExcelError.ExcelErrorNA, data[1, 0]);
+    }
+
+    [Fact]
+    public void TestStruct()
+    {
+        var data = DuckDbHelper.ExecuteQuery("SELECT {'id': 101, 'status': 'active'}");
+        Assert.NotNull(data);
+        var json = Assert.IsType<string>(data[1, 0]);
+        var dict = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+        Assert.NotNull(dict);
+        Assert.Equal(101, dict["id"].GetInt32());
+        Assert.Equal("active", dict["status"].GetString());
+    }
+
+    [Fact]
+    public void TestMap()
+    {
+        var data = DuckDbHelper.ExecuteQuery("SELECT map(['color', 'shape'], ['red', 'circle'])");
+        Assert.NotNull(data);
+        var json = Assert.IsType<string>(data[1, 0]);
+        var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+        Assert.NotNull(dict);
+        Assert.Equal("red", dict["color"]);
+        Assert.Equal("circle", dict["shape"]);
     }
 }

--- a/xlDuckDb/DuckDbHelper.cs
+++ b/xlDuckDb/DuckDbHelper.cs
@@ -1,6 +1,8 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Text;
+using System.Text.Json;
 using DuckDB.NET.Data;
 using DuckDB.NET.Native;
 using ExcelDna.Integration;
@@ -62,6 +64,7 @@ public static class DuckDbHelper
         var timeTzField = new bool[reader.FieldCount];
         var dateOnlyField = new bool[reader.FieldCount];
         var uuidField = new bool[reader.FieldCount];
+        var jsonSerializeField = new bool[reader.FieldCount];
 
         for (var i = 0; i < reader.FieldCount; i++)
         {
@@ -76,6 +79,8 @@ public static class DuckDbHelper
             timeTzField[i] = fieldType == typeof(DateTimeOffset);
             dateOnlyField[i] = fieldType == typeof(DateOnly);
             uuidField[i] = fieldType == typeof(Guid);
+            jsonSerializeField[i] = typeof(IList).IsAssignableFrom(fieldType) ||
+                                    typeof(IDictionary).IsAssignableFrom(fieldType);
         }
 
         // Add the first row of column names
@@ -126,6 +131,12 @@ public static class DuckDbHelper
                 else if (uuidField[i])
                 {
                     rowData[i] = (reader.GetGuid(i)).ToString();
+                }
+                else if (jsonSerializeField[i])
+                {
+                    rowData[i] = reader.IsDBNull(i)
+                        ? (object)ExcelError.ExcelErrorNA
+                        : JsonSerializer.Serialize(reader.GetValue(i));
                 }
                 else
                 {


### PR DESCRIPTION
DuckDB.NET returns .NET collection objects (`List<T>`, `Dictionary<K,V>`) for complex column types
Excel-DNA does not marshal these, producing `#VALUE!` errors

This change JSON-serializes collection-typed columns so they display as readable strings in Excel

### Given

```sql
FROM (
    VALUES (
        ['apple', 'banana', 'cherry']
        , { 'id': 101, 'status': 'active', 'score': 9.5 }
        , MAP(['color', 'shape', 'material'], ['red', 'circle', 'wood'])
        , '{"meta": {"tags": ["sql", "duckdb"], "version": 1.2}}'::JSON
    )
) AS test (example_list, example_struct, example_map, example_json)
;
```

### Before

| example_list | example_struct | example_map | example_json |
|---|---|---|---|
| `#VALUE!` | `#VALUE!` | `#VALUE!` | `{"meta": {"tags": ["sql", "duckdb"], "version": 1.2}}` |

### After

| example_list | example_struct | example_map | example_json |
|---|---|---|---|
| `["apple","banana","cherry"]` | `{"id":101,"status":"active","score":9.5}` | `{"color":"red","shape":"circle","material":"wood"}` | `{"meta": {"tags": ["sql", "duckdb"], "version": 1.2}}` |

### Changes

- **`DuckDbHelper.cs`** — Added `jsonSerializeField` flag for `IList`/`IDictionary` column types, serialized via `JsonSerializer.Serialize()`; null collections guard via `IsDBNull` → `#N/A`
- **`UnitTestDuckDbQueries.cs`** — Added tests for LIST, STRUCT, MAP, and null collections (LIST)

Assisted-by: Claude:claude-opus-4-6 [dotnet-test]
