### PR TITLE
Improve generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,16 +1,14 @@
 changelog:
   categories:
-    - title: Breaking Changes
-      labels:
-        - breaking-change
     - title: New Features
       labels:
         - enhancement
-        - feature
     - title: Bug Fixes
       labels:
         - bug
-        - bugfix
+    - title: Documentation
+      labels:
+        - documentation
     - title: Other Changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+        - bugfix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
   build:
     runs-on: windows-2022 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
   build:
     runs-on: windows-2022 
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies
@@ -26,11 +26,21 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal -c Release
 
+    - name: Publish release files
+      run: |
+        dotnet publish ./xlDuckDb/xlDuckDb.csproj --no-restore --no-build -c Release -o ./publish
+        Copy-Item ./xlDuckDb/bin/Release/net8.0-windows/xlDuckDb64.* ./publish -Force
+
+    - name: Verify release artifact
+      run: |
+        if (!(Test-Path ./publish/xlDuckDb64.xll)) {
+          throw "Expected xlDuckDb64.xll was not produced"
+        }
     - name: ZIP release artifact
-      run: Compress-Archive -Path ./xlDuckDb/bin/Release/net8.0-windows/* -Destination xlduckdb.zip
+      run: Compress-Archive -Path ./publish/* -Destination xlduckdb.zip
 
     # Create release
-    - uses: ncipollo/release-action@v1
+    - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
       with:
         artifacts: "xlduckdb.zip"
         generateReleaseNotes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "xlduckdb.zip"
+        generateReleaseNotes: true
         makelatest: true
         allowupdates: true
         artifacterrorsfailbuild: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
     - name: Validate release tag
       shell: pwsh
       run: |
@@ -27,7 +27,7 @@ jobs:
           throw "Release tag '$env:GITHUB_REF_NAME' must use vMAJOR.MINOR.PATCH format"
         }
     - name: Setup .NET
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,24 @@ on:
     tags:
     - 'v*'
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: windows-2022
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+    - name: Validate release tag
+      shell: pwsh
+      run: |
+        if ($env:GITHUB_REF_NAME -notmatch '^v\d+\.\d+\.\d+$') {
+          throw "Release tag '$env:GITHUB_REF_NAME' must use vMAJOR.MINOR.PATCH format"
+        }
     - name: Setup .NET
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
       with:
@@ -38,12 +49,17 @@ jobs:
         }
     - name: ZIP release artifact
       run: Compress-Archive -Path ./publish/* -Destination xlduckdb.zip
+    - name: Create release checksum
+      shell: pwsh
+      run: |
+        $hash = (Get-FileHash ./xlduckdb.zip -Algorithm SHA256).Hash
+        "$hash  xlduckdb.zip" | Set-Content ./xlduckdb.zip.sha256
 
     # Create release
     - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
       with:
-        artifacts: "xlduckdb.zip"
+        artifacts: "xlduckdb.zip,xlduckdb.zip.sha256"
         generateReleaseNotes: true
         makelatest: true
-        allowupdates: true
+        allowUpdates: false
         artifacterrorsfailbuild: true


### PR DESCRIPTION
## Summary
- enable GitHub-generated release notes for tagged releases
- categorize release notes into breaking changes, features, bug fixes, and other changes

## Validation
- dotnet test --no-restore --verbosity minimal — 33 passed, 1 skipped
- git diff --check